### PR TITLE
Use the sector_size given by the block device via its info

### DIFF
--- a/bench/read.ml
+++ b/bench/read.ml
@@ -8,10 +8,10 @@ open Toolkit
 let mount =
   let open Lwt.Infix in
   Block.connect "mount chamelon" >>= fun block ->
-  Chamelon.format ~program_block_size:16 ~block_size:512 block >>= function
+  Chamelon.format ~program_block_size:16 block >>= function
   | Error _ -> assert false
   | Ok () ->
-    Chamelon.connect ~program_block_size:16 ~block_size:512 block >>= function
+    Chamelon.connect ~program_block_size:16 block >>= function
     | Error _ -> assert false
     | Ok fs -> Lwt.return fs
 

--- a/mirage/kv.ml
+++ b/mirage/kv.ml
@@ -224,7 +224,13 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
 
   let disconnect _ = Lwt.return_unit
 
-  let connect = Fs.connect
+  let connect ~program_block_size block =
+    Sectors.get_info block >>= fun info ->
+    let block_size = info.Mirage_block.sector_size in
+    Fs.connect ~program_block_size ~block_size block
 
-  let format = Fs.format
+  let format ~program_block_size block =
+    Sectors.get_info block >>= fun info ->
+    let block_size = info.Mirage_block.sector_size in
+    Fs.format ~program_block_size ~block_size block
 end

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -2,7 +2,7 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
 
   include Mirage_kv.RW
 
-  val format : program_block_size:int -> block_size:int -> Sectors.t -> (unit, write_error) result Lwt.t
-  val connect : program_block_size:int -> block_size:int -> Sectors.t -> (t, error) result Lwt.t
+  val format : program_block_size:int -> Sectors.t -> (unit, write_error) result Lwt.t
+  val connect : program_block_size:int -> Sectors.t -> (t, error) result Lwt.t
 
 end

--- a/mirage_test/test_dirs.ml
+++ b/mirage_test/test_dirs.ml
@@ -11,19 +11,19 @@ let fail_write = fail Chamelon.pp_write_error
 let testable_key = Alcotest.testable Mirage_kv.Key.pp Mirage_kv.Key.equal
 
 let program_block_size = 16
-let block_size = 512
+(* let block_size = 512 *)
 
 let rec do_many fs ~f = function
   | n when n <= 0 -> Lwt.return_unit
   | n -> f fs n >>= fun () -> do_many fs ~f (n-1)
 
 let just_mount block =
-  Chamelon.connect ~program_block_size ~block_size block >>= function
+  Chamelon.connect ~program_block_size block >>= function
   | Error e -> fail_read e
   | Ok fs -> Lwt.return fs
 
 let format_and_mount block =
-  Chamelon.format ~program_block_size ~block_size block >>= function
+  Chamelon.format ~program_block_size block >>= function
   | Error e -> fail_write e
   | Ok () -> just_mount block
 
@@ -162,7 +162,7 @@ let test img =
   let open Alcotest_lwt in
   let open Lwt.Infix in
   Lwt_main.run @@ (
-    Block.connect img >>= fun block ->
+    Block.connect ~prefered_sector_size:(Some 512) img >>= fun block ->
     run "directories" [
       ("from_toml", [
           test_case "root" `Quick (test_root block);

--- a/mirage_test/test_mirage.ml
+++ b/mirage_test/test_mirage.ml
@@ -17,18 +17,18 @@ let rec write_until_full ~write fs n =
   | true -> write_until_full ~write fs (n+1)
 
 let format_and_mount block =
-  Chamelon.format ~program_block_size ~block_size block >>= function
+  Chamelon.format ~program_block_size block >>= function
   | Error e -> fail_write e
   | Ok () ->
-    Chamelon.connect ~program_block_size ~block_size block >>= function
+    Chamelon.connect ~program_block_size block >>= function
     | Error e -> fail_read e
     | Ok fs -> Lwt.return fs
 
 let test_format block _ () =
-  Chamelon.format ~program_block_size ~block_size block >>= function
+  Chamelon.format ~program_block_size block >>= function
   | Error e -> fail_write e
   | Ok () ->
-    Chamelon.connect ~program_block_size ~block_size block >>= function
+    Chamelon.connect ~program_block_size block >>= function
     | Error e -> Alcotest.failf "couldn't mount the filesystem after formatting it: %a" Chamelon.pp_error e
     | Ok fs ->
       Chamelon.list fs (Mirage_kv.Key.v "/") >>= function
@@ -286,7 +286,7 @@ let test img =
   let open Alcotest_lwt in
   let open Lwt.Infix in
   Lwt_main.run @@ (
-    Block.connect img >>= fun block ->
+    Block.connect ~prefered_sector_size:(Some 512) img >>= fun block ->
     run "mirage-kv" [
       ("format",
        [ test_case "format" `Quick (test_format block) ;

--- a/src/lfs_ls.ml
+++ b/src/lfs_ls.ml
@@ -28,8 +28,8 @@ let ls {Common_options.image; block_size; program_block_size} timestamp path =
           Lwt.return @@ Ok (`Ptime timestamp)
   in
   Lwt_main.run @@ (
-  Mirage_block.connect image >>= fun block ->
-  Chamelon.connect block ~program_block_size ~block_size >>= function
+  Mirage_block.connect ~prefered_sector_size:(Some block_size) image >>= fun block ->
+  Chamelon.connect block ~program_block_size >>= function
   | Error _ -> Stdlib.Format.eprintf "Error doing the initial filesystem ls\n%!"; exit 1
   | Ok t ->
     let requested_path = Mirage_kv.Key.v path in


### PR DESCRIPTION
Instead to require a `block_size` argument on the `connect` function, the given block can help us to get such information via `Block.get_info`. By this way, we don't do a mistake on this parameter 👍 . `mirage-block-unix` (/cc @Julow) helps us with a `prefered_sector_size` when we want to connect our block-device. By this way, I ensured that the behavior of `chamelon` is pretty the same with a `~block_size:512`.

Let me know about this PR - and I think you should have an access into `ocaml-ci` to get a proper CI in this repository.

This PR mostly helps what it will be the `chamelon` device - see mirage/mirage#1300.