### PR TITLE
Kv: add signature S

### DIFF
--- a/mirage/kv.ml
+++ b/mirage/kv.ml
@@ -4,6 +4,20 @@ open Lwt.Infix
  * is always at a constant pair - addresses (0, 1) *)
 let root_pair = (0L, 1L)
 
+module type S = sig
+
+  include Mirage_kv.RW
+
+  type sectors
+
+  val format : program_block_size:int -> sectors -> (unit, write_error) result Lwt.t
+  val connect : program_block_size:int -> sectors -> (t, error) result Lwt.t
+  val size : t -> key -> (int, error) result Lwt.t
+
+  val get_partial : t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
+
+end
+
 module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
   module Fs = Fs.Make(Sectors)(Clock)
 

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -6,8 +6,10 @@ module type S = sig
 
   include Mirage_kv.RW
 
-  val format : program_block_size:int -> Sectors.t -> (unit, write_error) result Lwt.t
-  val connect : program_block_size:int -> Sectors.t -> (t, error) result Lwt.t
+  type sectors
+
+  val format : program_block_size:int -> sectors -> (unit, write_error) result Lwt.t
+  val connect : program_block_size:int -> sectors -> (t, error) result Lwt.t
   val size : t -> key -> (int, error) result Lwt.t
 
   (** [get_partial t k ~offset ~length] gives errors for length <= 0 and offset < 0.
@@ -16,4 +18,4 @@ module type S = sig
 
 end
 
-module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : S
+module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : S with type sectors := Sectors.t

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -2,7 +2,7 @@
  * Many functions contain calls to the Fs module, which provides lower-level operations
  * dealing directly with on-disk structures. *)
 
-module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
+module type S = sig
 
   include Mirage_kv.RW
 
@@ -15,3 +15,5 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
   val get_partial : t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
 
 end
+
+module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : S


### PR DESCRIPTION
Then in Unikernel.Make you can take as argument a module (My_kv : Kv.S) instead of repeating the signature from kv.mli.

Marking it as a draft as I'm not sure if this is the best way to achieve it.