### PR TITLE
Add failing test discovered in opam-mirror

### DIFF
--- a/mirage_test/dune
+++ b/mirage_test/dune
@@ -7,6 +7,7 @@
   (alias runtest)
   (action (progn
             (run dd if=/dev/zero of=emptyfile bs=4K count=10)
+            (run fallocate -l 64M 64mbfile)
             (run %{exe:test_mirage.exe})
             (run dd if=/dev/zero of=emptyfile bs=1M count=10)
             (run %{exe:test_dirs.exe})

--- a/mirage_test/test_mirage.ml
+++ b/mirage_test/test_mirage.ml
@@ -464,6 +464,8 @@ let test_rm_slash block _ () =
 
 let test_set_2mb_set_2mb_reset_2mb block _ () =
   let md5s = Mirage_kv.Key.v "md5s" and sha512s = Mirage_kv.Key.v "sha512s" in
+  (* disable debug logging while writing large files *)
+  Logs.set_level (Some Logs.Info);
   format_and_mount block >>= fun fs ->
   Chamelon.set fs md5s
     (String.init (2 * 1024 * 1024) (Fun.const '\001'))
@@ -471,10 +473,12 @@ let test_set_2mb_set_2mb_reset_2mb block _ () =
   Chamelon.set fs sha512s
     (String.init (2 * 1024 * 1024) (Fun.const '\002'))
   >>= function Error e -> fail_write e | Ok () ->
+  (* reenable debug logging *)
+  Logs.set_level (Some Logs.Debug);
   Chamelon.disconnect fs >>= fun () ->
   Chamelon.connect ~program_block_size block
   >>= function Error e -> fail_read e | Ok fs ->
-  Chamelon.set fs md5s (String.init (2 * 1024 * 1024 + 16 * 1024) (Fun.const '\003'))
+  Chamelon.set fs md5s (String.init (2 * 1024) (Fun.const '\003'))
   >>= function Error e -> fail_write e | Ok () ->
   Lwt.return ()
 


### PR DESCRIPTION
This failing test uses a 64 MB filesystem. It first writes two files of size 2 MiB. Then it disconnects and connects again, and sets one of the files to a value slightly larger than 2 MiB. Then chamelon fails and complains about lack of space.

I can try to minimize the test case as the large-ish sizes result in a lot of debug output.