### PR TITLE
Break cycle between Dir and Entry (dune 3.7)

### DIFF
--- a/lib/dir.mli
+++ b/lib/dir.mli
@@ -2,16 +2,16 @@
  * if [t] is a hard tail entry *)
 val hard_tail_links : Tag.t * Cstruct.t -> (int64 * int64) option
 
-val hard_tail_at : (int64 * int64) -> Entry.t
+val hard_tail_at : (int64 * int64) -> Entry0.t
 
 (** [of_entry t] returns the blockpair on which the directory contents start
  * if [t] is a directory structure entry *)
-val of_entry : Entry.t -> (int64 * int64) option
+val of_entry : Entry0.t -> (int64 * int64) option
 
 (** [name str id] makes an entry linking [id] with [name]. *)
-val name : string -> int -> Entry.t
+val name : string -> int -> Entry0.t
 
 (** [mkdir ~to_pair id] makes a directory structure entry. *)
-val mkdir : to_pair:(int64 * int64) -> int -> Entry.t
+val mkdir : to_pair:(int64 * int64) -> int -> Entry0.t
 
 val dirstruct_of_cstruct : Cstruct.t -> (int64 * int64) option

--- a/lib/entry.mli
+++ b/lib/entry.mli
@@ -1,4 +1,4 @@
-type t = Tag.t * Cstruct.t
+type t = Entry0.t
 type link = | Metadata of (int64 * int64)
             | Data of (int32 * int32)
 

--- a/lib/entry0.ml
+++ b/lib/entry0.ml
@@ -1,0 +1,1 @@
+type t = Tag.t * Cstruct.t


### PR DESCRIPTION
Hi!

While preparing dune 3.7 we noticed that this library used to build, but does not anymore.
After investigating, there is a dependency cycle in `lib`: `entry.ml` depends on `Dir`, and `dir.mli` depends on `Entry`.

Dune used to be OK with that, but the new dependency analysis algorithm in 3.7 makes tighter checks and (correctly) detects it. It's kinda OK in that particular case because `Dir` only uses a type alias for `Entry`, but dune can not reliably detect this. So arguably `chamelon` used to rely on a bug in dune.

So this PR adds an extra `Entry0` module with just the type definition, in a way that splits the cycle and makes it compatible with dune 3.7.

A alternative would be to expand the type alias in `dir.mli`.
