### PR TITLE
Update to Mirage_kv 6.0.1

### DIFF
--- a/bench/read.ml
+++ b/bench/read.ml
@@ -10,6 +10,7 @@ let ascii_denom = 128
 let comparator = String.init ascii_denom (fun f -> Char.chr f)
  
 let simple_get_partial t key ~offset ~length =
+  let offset = Optint.Int63.to_int offset in
   if offset < 0 then begin
     Logs.err (fun f -> f "read requested with negative offset");
     Lwt.return @@ Error (`Not_found key)
@@ -55,7 +56,7 @@ let head ~readfn n =
     let rec aux = function
       | n when n <= 0 -> Lwt.return_unit
       | n ->
-        readfn fs key ~offset:0 ~length:ascii_denom >>= function
+        readfn fs key ~offset:(Optint.Int63.of_int 0) ~length:ascii_denom >>= function
         | Error e -> Format.eprintf "error reading test key: %a" Chamelon.pp_error e;
           assert false
         | Ok subset ->
@@ -77,7 +78,7 @@ let tail ~readfn n =
     let rec aux = function
       | n when n <= 0 -> Lwt.return_unit
       | n ->
-        readfn fs key ~offset:(size - ascii_denom) ~length:ascii_denom >>= function
+        readfn fs key ~offset:(Optint.Int63.of_int ((Optint.Int63.to_int size) - ascii_denom)) ~length:ascii_denom >>= function
         | Error e -> Format.eprintf "error reading test key: %a" Chamelon.pp_error e;
           assert false
         | Ok subset ->

--- a/chamelon-unix.opam
+++ b/chamelon-unix.opam
@@ -29,6 +29,6 @@ depends: [
   "mirage-block-unix" {>= "2.13.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-clock-unix" {>= "4.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
 ]

--- a/chamelon-unix.opam
+++ b/chamelon-unix.opam
@@ -29,6 +29,6 @@ depends: [
   "mirage-block-unix" {>= "2.13.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-clock-unix" {>= "4.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "6.0.0"}
   "mirage-logs" {>= "1.2.0"}
 ]

--- a/chamelon-unix.opam
+++ b/chamelon-unix.opam
@@ -29,6 +29,6 @@ depends: [
   "mirage-block-unix" {>= "2.13.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-clock-unix" {>= "4.0.0"}
-  "mirage-kv" {>= "6.0.0"}
+  "mirage-kv" {>= "6.0.1"}
   "mirage-logs" {>= "1.2.0"}
 ]

--- a/chamelon.opam
+++ b/chamelon.opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-block-combinators" {>= "3.0.0" & with-test}
   "mirage-block-unix" {>= "2.13.0" & with-test}
   "mirage-clock-unix" {>= "4.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "1.2.0" & with-test}
   "bechamel" {>= "0.2.0" & with-test}
   "bechamel-js" {>= "0.2.0" & with-test}
   "checkseum" {>= "0.3.2"}

--- a/chamelon.opam
+++ b/chamelon.opam
@@ -41,7 +41,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "6.0.0"}
+  "mirage-kv" {>= "6.0.1"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/chamelon.opam
+++ b/chamelon.opam
@@ -41,7 +41,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "6.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/chamelon.opam
+++ b/chamelon.opam
@@ -41,7 +41,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/mirage/fs.ml
+++ b/mirage/fs.ml
@@ -769,8 +769,7 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
       match Mirage_kv.Key.segments key with
       | [] -> size_all t root_pair >>= fun i -> Lwt.return @@ Ok (Optint.Int63.of_int i)
       | basename::[] -> get_file_size t root_pair basename
-      | _ ->
-        let segments = Mirage_kv.Key.segments key in
+      | segments ->
         Log.debug (fun f -> f "descending into segments %a" Fmt.(list ~sep:comma string) segments);
         Find.find_first_blockpair_of_directory t root_pair segments >>= function
         | `Basename_on p -> size_all t p >|= fun i -> Ok (Optint.Int63.of_int i)

--- a/mirage/fs.ml
+++ b/mirage/fs.ml
@@ -442,7 +442,6 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
 	  match Chamelon.Entry.ctime_of_cstruct data with
 	  | None ->
 	    Log.err (fun m -> m "Time attributes (%a) found for %a but they were not parseable" Cstruct.hexdump_pp data Mirage_kv.Key.pp key);
-
 	    Lwt.return @@ Error (`Not_found key)
 	  | Some k -> Lwt.return @@ Ok (Ptime.v k)
 

--- a/mirage/kv.ml
+++ b/mirage/kv.ml
@@ -246,7 +246,7 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
 
 
   (* These (set_partial and rename) are really simple implementations just to be compliant with mirage-kv 5.0.0 *)
-  let set_partial t key offset data: (unit, write_error) result Lwt.t =
+  let set_partial t key ~offset data =
     get t key >>= function
     | Ok v ->
       let v' = String.sub v 0 (min offset (String.length v)) in
@@ -258,7 +258,7 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
     | Error (`Not_found _) -> set t key data
     | Error _ -> Lwt.return @@ Error (`Not_found key) (* fall back to a "generic error" *)
 
-  let rename t source dest: (unit, write_error) result Lwt.t =
+  let rename t ~source ~dest =
     get t source >>= function
     | Ok v ->
       set t dest v >>= begin function

--- a/mirage/kv.ml
+++ b/mirage/kv.ml
@@ -178,7 +178,7 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
             match entry with
             | _, `Dictionary -> Lwt.return @@ Ok prev
             | (name, `Value) ->
-              Fs.last_modified_value t name >>= fun new_span ->
+              Fs.last_modified_value t (Mirage_kv.Key.append key name) >>= fun new_span ->
               if Ptime.is_later new_span ~than:prev
               then Lwt.return @@ Ok new_span
               else Lwt.return @@ Ok prev
@@ -212,7 +212,7 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
                   match ctx_result with
                   | Error _ as e -> Lwt.return e
                   | Ok ctx ->
-                    aux ctx t path
+                    aux ctx t (Mirage_kv.Key.append key path)
                 ) (Ok ctx) l
             end
         end

--- a/mirage/kv.ml
+++ b/mirage/kv.ml
@@ -260,7 +260,7 @@ module Make(Sectors : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
     | Error (`Not_found _) -> Lwt.return @@ Error (`Value_expected source)
     | Error _ -> Lwt.return @@ Error (`Not_found source) (* fall back to a "generic error" *)
 
-  let allocate t key ?last_modified size =
+  let allocate t key ?last_modified:_ size =
     let data = String.make (Optint.Int63.to_int size) '\000' in
     set t key data
 

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -14,6 +14,6 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
    * [get_partial t k ~offset ~length], if successful, gives a result of (Ok v) where String.length v <= [length]. If [offset + length] is greater than the file length, (Ok v) is returned where [v]'s first byte is [offset] and its last byte is the last byte in the file. *)
   val get_partial : t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
 
-  val set_partial : t -> key -> int -> string -> (unit, write_error) result Lwt.t
-  val rename : t -> key -> key -> (unit, write_error) result Lwt.t
+  val set_partial : t -> key -> offset:int -> string -> (unit, write_error) result Lwt.t
+  val rename : t -> source:key -> dest:key -> (unit, write_error) result Lwt.t
 end

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -8,12 +8,13 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
 
   val format : program_block_size:int -> Sectors.t -> (unit, write_error) result Lwt.t
   val connect : program_block_size:int -> Sectors.t -> (t, error) result Lwt.t
-  val size : t -> key -> (int, error) result Lwt.t
+  val size : t -> key -> (Optint.Int63.t, error) result Lwt.t
 
   (** [get_partial t k ~offset ~length] gives errors for length <= 0 and offset < 0.
    * [get_partial t k ~offset ~length], if successful, gives a result of (Ok v) where String.length v <= [length]. If [offset + length] is greater than the file length, (Ok v) is returned where [v]'s first byte is [offset] and its last byte is the last byte in the file. *)
-  val get_partial : t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
+  val get_partial : t -> key -> offset:Optint.Int63.t -> length:int -> (string, error) result Lwt.t
 
-  val set_partial : t -> key -> offset:int -> string -> (unit, write_error) result Lwt.t
+  val set_partial : t -> key -> offset:Optint.Int63.t -> string -> (unit, write_error) result Lwt.t
   val rename : t -> source:key -> dest:key -> (unit, write_error) result Lwt.t
+
 end

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -14,4 +14,6 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
    * [get_partial t k ~offset ~length], if successful, gives a result of (Ok v) where String.length v <= [length]. If [offset + length] is greater than the file length, (Ok v) is returned where [v]'s first byte is [offset] and its last byte is the last byte in the file. *)
   val get_partial : t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
 
+  val set_partial : t -> key -> int -> string -> (unit, write_error) result Lwt.t
+  val rename : t -> key -> key -> (unit, write_error) result Lwt.t
 end

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -16,5 +16,6 @@ module Make(Sectors: Mirage_block.S)(Clock : Mirage_clock.PCLOCK) : sig
 
   val set_partial : t -> key -> offset:Optint.Int63.t -> string -> (unit, write_error) result Lwt.t
   val rename : t -> source:key -> dest:key -> (unit, write_error) result Lwt.t
+  val allocate : t -> key -> ?last_modified:Ptime.t -> Optint.Int63.t -> (unit, write_error) result Lwt.t
 
 end

--- a/mirage_test/dune
+++ b/mirage_test/dune
@@ -1,6 +1,6 @@
 (executables
   (names mem_test_read test_cycles test_dirs test_mirage)
-  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-crypto-rng mirage-crypto-rng.lwt mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
+  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-crypto-rng mirage-crypto-rng-lwt mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
 )
 
 (rule

--- a/mirage_test/dune
+++ b/mirage_test/dune
@@ -1,6 +1,6 @@
 (executables
   (names mem_test_read test_cycles test_dirs test_mirage)
-  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-crypto-rng mirage-crypto-rng-lwt mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
+  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-crypto-rng mirage-crypto-rng.unix mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
 )
 
 (rule

--- a/mirage_test/mem_test_read.ml
+++ b/mirage_test/mem_test_read.ml
@@ -35,7 +35,7 @@ let head ~readfn n =
     let rec aux = function
       | n when n <= 0 -> Lwt.return_unit
       | n ->
-        readfn fs key ~offset:0 ~length:128 >>= function
+        readfn fs key ~offset:(Optint.Int63.of_int 0) ~length:128 >>= function
         | Error e ->
           Alcotest.failf "error reading test key: %a" Chamelon.pp_error e
         | Ok subset ->
@@ -58,7 +58,8 @@ let tail ~readfn n =
       | n when n <= 0 -> Lwt.return_unit
       | n ->
         (* look for `ascii_denom + 1` as a cheap and cheerful way of testing short reads *)
-        readfn fs key ~offset:(size - ascii_denom) ~length:(2 * ascii_denom + 1) >>= function
+        let offset = Optint.Int63.of_int ((Optint.Int63.to_int size) - ascii_denom) in
+        readfn fs key ~offset ~length:(2 * ascii_denom + 1) >>= function
         | Error e -> Alcotest.failf "error reading test key: %a" Chamelon.pp_error e
         | Ok subset ->
           Alcotest.(check string) "tail subset" comparator subset;
@@ -78,7 +79,7 @@ let block_straddling_read () =
   Lwt_main.run @@ (
     let open Lwt.Infix in
     mount_and_write >>= fun fs ->
-    Chamelon.get_partial fs key ~offset:511 ~length:3 >>= function
+    Chamelon.get_partial fs key ~offset:(Optint.Int63.of_int 511) ~length:3 >>= function
     | Error e -> Alcotest.failf "error reading test key: %a" Chamelon.pp_error e
     | Ok read -> 
       Alcotest.(check string) "block-straddling read" "\x7f\x00\x01" read;

--- a/mirage_test/test_dirs.ml
+++ b/mirage_test/test_dirs.ml
@@ -69,7 +69,7 @@ let list fs ~ty n =
   Chamelon.list fs Mirage_kv.Key.empty >|= Result.get_ok >>= fun l ->
   let matching = List.filter
       (fun (name, val_or_dict) -> String.equal name s && val_or_dict = ty)
-      (List.map (fun (k,t) -> (Mirage_kv.Key.to_string k, t)) l) in
+      (List.map (fun (k,t) -> (Mirage_kv.Key.basename k, t)) l) in
   Alcotest.(check int) "each directory appears once in ls /" 1 (List.length matching);
   Lwt.return_unit
 

--- a/mirage_test/test_dirs.ml
+++ b/mirage_test/test_dirs.ml
@@ -30,7 +30,7 @@ let assert_slash_empty fs =
   Chamelon.list fs Mirage_kv.Key.empty >>= function
   | Error e -> fail_read e
   | Ok l ->
-    Format.printf "%a\n%!" Fmt.(list ~sep:comma string) (List.map fst l);
+    Format.printf "%a\n%!" Fmt.(list ~sep:comma string) (List.map Mirage_kv.Key.to_string (List.map fst l));
     Alcotest.(check int) "fs should be empty after deleting everything" 0 (List.length l); Lwt.return_unit
 
 (* root *)
@@ -69,7 +69,7 @@ let list fs ~ty n =
   Chamelon.list fs Mirage_kv.Key.empty >|= Result.get_ok >>= fun l ->
   let matching = List.filter
       (fun (name, val_or_dict) -> String.equal name s && val_or_dict = ty)
-      l in
+      (List.map (fun (k,t) -> (Mirage_kv.Key.to_string k, t)) l) in
   Alcotest.(check int) "each directory appears once in ls /" 1 (List.length matching);
   Lwt.return_unit
 

--- a/mirage_test/test_mirage.ml
+++ b/mirage_test/test_mirage.ml
@@ -433,7 +433,7 @@ let test_many_files block _ () =
   Logs.debug (fun f -> f "last written file was %d" last_written);
   Alcotest.(check bool) "we managed to write at least one file" true (last_written > 0);
   Chamelon.list fs Mirage_kv.Key.empty >>= function | Error e -> fail_read e | Ok l ->
-  let names = List.map (fun (n, _) -> Mirage_kv.Key.to_string n) l |> List.fast_sort (fun a b -> Int.compare (int_of_string a) (int_of_string b)) in
+  let names = List.map (fun (n, _) -> Mirage_kv.Key.basename n) l |> List.fast_sort (fun a b -> Int.compare (int_of_string a) (int_of_string b)) in
   Logs.debug (fun f -> f "%a" Fmt.(list ~sep:sp string) names);
   Alcotest.(check int) "ls contains all written files" (last_written + 1) (List.length l);
   (* make sure each key has the correct corresponding value *)

--- a/mirage_test/test_mirage.ml
+++ b/mirage_test/test_mirage.ml
@@ -319,13 +319,13 @@ let test_get_big_value block _ () =
   format_and_mount block >>= fun fs ->
   let g = Mirage_crypto_rng.default_generator () in
   let value = Mirage_crypto_rng.generate ~g (block_size * 4) in
-  Chamelon.set fs key (Cstruct.to_string value) >>= function
+  Chamelon.set fs key value >>= function
   | Error e -> Alcotest.fail (Format.asprintf "setting a large key failed: %a" Chamelon.pp_write_error e)
   | Ok () ->
     Chamelon.get fs key >>= function
     | Error e -> Alcotest.fail (Format.asprintf "getting a large key failed: %a" Chamelon.pp_error e)
     | Ok retrieved_value ->
-      Alcotest.(check string "retrieved big file is the same as what we set" (Cstruct.to_string value) retrieved_value);
+      Alcotest.(check string "retrieved big file is the same as what we set" value retrieved_value);
       Lwt.return_unit
 
 let test_get_valid_partial block _ () =
@@ -599,7 +599,6 @@ let test img =
   let open Alcotest_lwt in
   let open Lwt.Infix in
   Lwt_main.run @@ (
-    Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
     Block.connect ~prefered_sector_size:(Some 512) img >>= fun block ->
     run "mirage-kv" [
       ("format",
@@ -674,4 +673,7 @@ let test img =
        ]);
     ]
   )
-let () = test "emptyfile"
+
+let () =
+  Mirage_crypto_rng_unix.use_default ();
+  test "emptyfile"

--- a/src/chamelon.ml
+++ b/src/chamelon.ml
@@ -54,9 +54,6 @@ let remove common_options path =
       (* it's unclear to me how we'd end up here, which means we definitely want a clear error message *)
       Format.eprintf "value expected for %a but there wasn't one\n%!" Mirage_kv.Key.pp k;
       exit 1
-    | Error (`Too_many_retries i) ->
-      Format.eprintf "couldn't execute deletion batch after %d tries\n%!" i;
-      exit 1
     | Error e -> Format.eprintf "error deleting: %a" Littlefs.pp_write_error e; exit 1
   )
 

--- a/src/dune
+++ b/src/dune
@@ -31,7 +31,7 @@
             (setenv OCAMLRUNPARAM b (run %{exe:chamelon.exe} format test.img))
             (setenv OCAMLRUNPARAM b (with-stdin-from colossal (run %{exe:chamelon.exe} write --verbosity=debug test.img 4096 "colossal.bak" -)))
 
-            (with-stdout-to colossal-ls.expected (run echo "colossal.bak : file"))
+            (with-stdout-to colossal-ls.expected (run echo "/colossal.bak : file"))
             (setenv OCAMLRUNPARAM b (with-stdout-to colossal-ls.output (run %{exe:chamelon.exe} ls test.img 4096 "/")))
             (diff colossal-ls.expected colossal-ls.output)
             
@@ -87,7 +87,7 @@
       (run chmod 666 test.img)
       (setenv OCAMLRUNPARAM b (run %{exe:chamelon.exe} write test.img 4096 "secrets/mom_dont_look" "I SAID NOT TO LOOK JEEZ"))
       (setenv OCAMLRUNPARAM b (with-stdout-to ls-secrets.output (run %{exe:chamelon.exe} ls test.img 4096 "/secrets")))
-      (with-stdout-to ls-secrets.expected (run echo "mom_dont_look : file"))
+      (with-stdout-to ls-secrets.expected (run echo "/secrets/mom_dont_look : file"))
       (diff ls-secrets.expected ls-secrets.output)
       (setenv OCAMLRUNPARAM b (with-stdout-to read-secrets.output (run %{exe:chamelon.exe} read test.img 4096 "secrets/mom_dont_look")))
       (with-stdout-to read-secrets.expected (run echo -n "I SAID NOT TO LOOK JEEZ"))


### PR DESCRIPTION
This PR is a naive implementation of Mirage_kv 5.0.0 (`set_partial` and `rename`), Mirage_kv 6.0.0 (`allocate`, use of `Ptime.t`, and `list` returning keys instead of strings). So far, the tests have been updated and pass. It as well works with mirage-sshfs with the #18 PR included.

I didn't dive too far into the code, I hope not, but I might have missed some optimizations. Don't hesitate if I need to fix some bits.