### PR TITLE
opam: add ppx_cstruct dependency explicitly

### DIFF
--- a/chamelon.opam
+++ b/chamelon.opam
@@ -43,5 +43,6 @@ depends: [
   "mirage-clock" {>= "2.0.0"}
   "mirage-kv" {>= "4.0.1"}
   "mirage-logs" {>= "1.2.0"}
+  "ppx_cstruct"
   "optint" {>= "0.0.4"}
 ]


### PR DESCRIPTION
mirage-logs 1.3.0 dropped it in the dependency cone, so better be explicit here