### PR TITLE
fix size returned type

### DIFF
--- a/mirage/fs.ml
+++ b/mirage/fs.ml
@@ -743,10 +743,10 @@ module Make(Sectors: Mirage_block.S) = struct
         match inline_files entries, ctz_files entries with
         | None, None -> Error (`Not_found (Mirage_kv.Key.v filename))
         | Some (tag, _data), None ->
-          Ok tag.Chamelon.Tag.length
+          Ok (Optint.Int63.of_int (tag.Chamelon.Tag.length))
         | _, Some (_tag, data) ->
           match Chamelon.File.ctz_of_cstruct data with
-          | Some (_pointer, length) -> Ok (Int32.to_int length)
+          | Some (_pointer, length) -> Ok (Optint.Int63.of_int (Int32.to_int length))
           | None -> Error (`Value_expected (Mirage_kv.Key.v filename))
 
     let rec size_all t blockpair =
@@ -763,15 +763,15 @@ module Make(Sectors: Mirage_block.S) = struct
               size_all t p >>= fun s -> Lwt.return @@ s + acc
           ) 0 entries
 
-    let size t key : (int, error) result Lwt.t =
+    let size t key : (Optint.Int63.t, error) result Lwt.t =
       Log.debug (fun f -> f "getting size on key %a" Mirage_kv.Key.pp key);
       match Mirage_kv.Key.segments key with
-      | [] -> size_all t root_pair >>= fun i -> Lwt.return @@ Ok i
+      | [] -> size_all t root_pair >>= fun i -> Lwt.return @@ Ok (Optint.Int63.of_int i)
       | basename::[] -> get_file_size t root_pair basename
       | segments ->
         Log.debug (fun f -> f "descending into segments %a" Fmt.(list ~sep:comma string) segments);
         Find.find_first_blockpair_of_directory t root_pair segments >>= function
-        | `Basename_on p -> size_all t p >|= fun i -> Ok i
+        | `Basename_on p -> size_all t p >|= fun i -> Ok (Optint.Int63.of_int i)
         | `No_id _ | `No_structs -> begin
             (* no directory by that name, so try for a file *)
             Find.find_first_blockpair_of_directory t root_pair segments >>= function

--- a/mirage/kv.mli
+++ b/mirage/kv.mli
@@ -8,6 +8,6 @@ module Make(Sectors: Mirage_block.S) : sig
 
   val format : program_block_size:int -> Sectors.t -> (unit, write_error) result Lwt.t
   val connect : program_block_size:int -> Sectors.t -> (t, error) result Lwt.t
-  val size : t -> key -> (int, error) result Lwt.t
+  val size : t -> key -> (Optint.Int63.t, error) result Lwt.t
 
 end


### PR DESCRIPTION
Dear @yomimono , some times ago I noticed a wrong type value for size. This PR complies with `val size: t -> key -> (Optint.Int63.t, error) result Lwt.t` as a change required for the API update.
I mistakenly sent a PR a while ago to https://github.com/hannesm/chamelon/pull/1.