### PR TITLE
remove the mirage-clock dependency

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,7 @@
 (executable
   (name read)
   (modules read)
-  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-kv logs.cli logs.fmt lwt chamelon.kv fpath bechamel bechamel-js)
+  (libraries mirage-block-combinators mirage-block-unix mirage-kv logs.cli logs.fmt lwt chamelon.kv fpath bechamel bechamel-js)
 )
 
 (rule

--- a/chamelon-unix.opam
+++ b/chamelon-unix.opam
@@ -27,8 +27,6 @@ depends: [
   "lwt" {>= "5.3.0"}
   "mirage-block" {>= "3.0.0"}
   "mirage-block-unix" {>= "2.13.0"}
-  "mirage-clock" {>= "2.0.0"}
-  "mirage-clock-unix" {>= "4.0.0"}
   "mirage-kv" {>= "4.0.1"}
   "mirage-logs" {>= "1.2.0"}
 ]

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,6 +1,6 @@
 (executable
   (name fuzz)
-  (libraries chamelon.kv crowbar cstruct logs.fmt lwt lwt.unix mirage-block-combinators mirage-clock-unix)
+  (libraries chamelon.kv crowbar cstruct logs.fmt lwt lwt.unix mirage-block-combinators)
 )
 
 (rule

--- a/mirage_test/dune
+++ b/mirage_test/dune
@@ -1,6 +1,6 @@
 (executables
   (names mem_test_read test_cycles test_dirs test_mirage)
-  (libraries mirage-block-combinators mirage-block-unix mirage-clock-unix mirage-crypto-rng mirage-crypto-rng.unix mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
+  (libraries mirage-block-combinators mirage-block-unix mirage-crypto-rng mirage-crypto-rng.unix mirage-kv logs.cli logs.fmt lwt chamelon chamelon.kv fpath alcotest alcotest-lwt)
 )
 
 (rule

--- a/src/chamelon.ml
+++ b/src/chamelon.ml
@@ -1,5 +1,5 @@
 module Mirage_sectors = Block (* disambiguate this from Littlefs.Block *)
-module Littlefs = Kv.Make(Mirage_sectors) (* Pclock comes from mirage-clock-unix *)
+module Littlefs = Kv.Make(Mirage_sectors) (* Pclock comes from mirage-ptime *)
 
 let format {Common_options.program_block_size; block_size; image} =
   let aux () =

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (executable
   (package chamelon-unix)
   (public_name chamelon)
-  (libraries bos cmdliner fmt fmt.cli fmt.tty chamelon.kv mirage-block-unix mirage-clock-unix mirage-kv logs.cli logs.fmt lwt)
+  (libraries bos cmdliner fmt fmt.cli fmt.tty chamelon.kv mirage-block-unix mirage-kv logs.cli logs.fmt lwt)
 )
 
 (rule


### PR DESCRIPTION
There's now mirage-ptime, which uses the linking trick to get the current time of day. No more need for the mirage-clock thingy. :)